### PR TITLE
Update README.md

### DIFF
--- a/Rethinking_2/README.md
+++ b/Rethinking_2/README.md
@@ -5,8 +5,8 @@
 In this repository we port [the book's original code in R and Stan](https://github.com/rmcelreath/rethinking) to Python and PyMC. We attempt to reproduce the examples as faithfully as possible while expressing them in a _Pythonic_ and _PyMConic_ way.
 
 ## Display notebooks
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/pymc-devs/resources/master?filepath=Rethinking_2)
-[<img src="http://nbviewer.jupyter.org/static/img/nav_logo.svg" width=120>](http://nbviewer.jupyter.org/github/pymc-devs/resources/blob/master/Rethinking_2)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/pymc-devs/resources/main?filepath=Rethinking_2)
+[<img src="http://nbviewer.jupyter.org/static/img/nav_logo.svg" width=120>](http://nbviewer.jupyter.org/github/pymc-devs/resources/blob/main/Rethinking_2)
 
 
 ## Contributing


### PR DESCRIPTION
fix: Binder link 404 (references master instead of main branch)

I just noticed this while browsing.